### PR TITLE
Bugfix/migrator empty connection string

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Simple URL shortener implemented using dotnet and C#
 
 ## How to run local instance
 
-`docker` and `docker compose V2+` are required
+_`docker` and `docker compose V2+` are required_
 
 1. Clone this repository
 2. Open your terminal in [`src`](src) directory
@@ -36,7 +36,7 @@ By default Urleso services are available at:
 
 - <http://localhost:6080> -> web app
 - <http://localhost:6800> -> API service
-- <http://localhost:6888> -> redirect service
+- <http://localhost:6880> -> redirect service
 - `postgresql://localhost:6432/urleso` -> PostgreSQL database
 
 ### Logging

--- a/src/Urleso.DatabaseMigrator/Program.cs
+++ b/src/Urleso.DatabaseMigrator/Program.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Steeltoe.Extensions.Configuration.Placeholder;
+﻿using Steeltoe.Extensions.Configuration.Placeholder;
 using Urleso.DatabaseMigrator;
 using Urleso.Persistence;
 
@@ -13,4 +11,4 @@ var host = Host.CreateDefaultBuilder(args)
     )
     .Build();
 
-await host.RunAsync();
+host.Run();

--- a/src/Urleso.DatabaseMigrator/Urleso.DatabaseMigrator.csproj
+++ b/src/Urleso.DatabaseMigrator/Urleso.DatabaseMigrator.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <Version>0.3.0</Version>
-        <OutputType>Exe</OutputType>
+        <Version>0.3.1</Version>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
 

--- a/src/Urleso.DatabaseMigrator/Urleso.DatabaseMigrator.csproj
+++ b/src/Urleso.DatabaseMigrator/Urleso.DatabaseMigrator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <Version>0.3.0</Version>

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -82,10 +82,15 @@ services:
     ports:
       - ${DATABASE_PORT}:5432
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -d ${DATABASE_NAME} -U ${DATABASE_USER}"
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 15s
 
   urleso.web.seq:
     image: datalust/seq:2023.4


### PR DESCRIPTION
Migrator appsettings.json file was not copied to build/publish output directory -> not connection string

Fix:
- migrator project sdk type
- link & formatting in readme
- postgres healthcheck in docker-compose